### PR TITLE
Generic left and right identity elements mechanisms

### DIFF
--- a/include/cpp-fold/fold/empty_fold.h
+++ b/include/cpp-fold/fold/empty_fold.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Morwenn
+ * Copyright (C) 2014-2015 Morwenn
  *
  * cpp-fold is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -26,12 +26,22 @@
 namespace cppfold
 {
     template<typename BinaryFunction>
-    struct empty_fold
+    struct empty_lfold
     {
         template<typename T>
         constexpr operator T() const
         {
-            return identity_element<T, BinaryFunction>::value;
+            return left_identity_element<T, BinaryFunction>::value;
+        }
+    };
+
+    template<typename BinaryFunction>
+    struct empty_rfold
+    {
+        template<typename T>
+        constexpr operator T() const
+        {
+            return right_identity_element<T, BinaryFunction>::value;
         }
     };
 }

--- a/include/cpp-fold/fold/lfold.h
+++ b/include/cpp-fold/fold/lfold.h
@@ -28,7 +28,7 @@ namespace cppfold
 {
     template<typename BinaryFunction>
     auto lfold()
-        -> empty_fold<BinaryFunction>
+        -> empty_lfold<BinaryFunction>
     {
         return {};
     }

--- a/include/cpp-fold/fold/rfold.h
+++ b/include/cpp-fold/fold/rfold.h
@@ -28,7 +28,7 @@ namespace cppfold
 {
     template<typename BinaryFunction>
     auto rfold()
-        -> empty_fold<BinaryFunction>
+        -> empty_rfold<BinaryFunction>
     {
         return {};
     }

--- a/include/cpp-fold/identity_element.h
+++ b/include/cpp-fold/identity_element.h
@@ -22,6 +22,12 @@ namespace cppfold
 {
     template<typename T, typename BinaryFunction>
     struct identity_element;
+
+    template<typename T, typename BinaryFunction>
+    struct right_identity_element;
+
+    template<typename T, typename BinaryFunction>
+    struct left_identity_element;
 }
 
 #endif // CPPFOLD_IDENTITY_ELEMENT_H_

--- a/include/cpp-fold/identity_element.h
+++ b/include/cpp-fold/identity_element.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Morwenn
+ * Copyright (C) 2014-2015 Morwenn
  *
  * cpp-fold is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -24,10 +24,14 @@ namespace cppfold
     struct identity_element;
 
     template<typename T, typename BinaryFunction>
-    struct right_identity_element;
+    struct right_identity_element:
+        identity_element<T, BinaryFunction>
+    {};
 
     template<typename T, typename BinaryFunction>
-    struct left_identity_element;
+    struct left_identity_element:
+        identity_element<T, BinaryFunction>
+    {};
 }
 
 #endif // CPPFOLD_IDENTITY_ELEMENT_H_


### PR DESCRIPTION
This adds two new kind of specializable identity element classes: `left_identity_element` and `right_identity_element`, which both inherit from `identity_element` to make it clear that an `identity_element` is both a left identity element and a right identity element.

Also, `lfold` now returns an `empty_lfold` and `rfold` returns and `empty_rfold` which can accordingly convert to the appropriate `left_identity_element` or `right_identity_element`.
